### PR TITLE
fix: correct double brand-name substitution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 ## Getting Started
 
-[TestMu AI](https://www.testmuai.com/) (Formerly TestMu AI (Formerly LambdaTest)) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks.
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks.
 
-With TestMu AI (Formerly TestMu AI (Formerly LambdaTest)), you can run Jest tests written in JavaScript on Node.js across a wide range of browsers and environments in the cloud.
+With TestMu AI (Formerly LambdaTest), you can run Jest tests written in JavaScript on Node.js across a wide range of browsers and environments in the cloud.
 
-- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly TestMu AI (Formerly LambdaTest)).
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ## Running locally
@@ -37,15 +37,15 @@ Run the following commands to setup the repository locally.
   
 - Push a new commit in the remote repository to trigger a new build on TAS.
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Community
+## TestMu AI (Formerly LambdaTest) Community
 
 Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Certifications
+## TestMu AI (Formerly LambdaTest) Certifications
 
 Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-## Learning Resources by TestMu AI (Formerly TestMu AI (Formerly LambdaTest))
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
 Learn modern testing through tutorials, guides, videos, and weekly updates:
 


### PR DESCRIPTION
Fix double-substituted "TestMu AI (Formerly TestMu AI (Formerly LambdaTest))" → "TestMu AI (Formerly LambdaTest)". Remove extra non-template badges.